### PR TITLE
Non-root changes

### DIFF
--- a/openmrs-maven-build/Dockerfile
+++ b/openmrs-maven-build/Dockerfile
@@ -1,25 +1,28 @@
-FROM maven:3-jdk-8
+FROM maven:3-jdk-8-slim
 
-MAINTAINER Michael Seaton <mseaton@pih.org>
+LABEL authors="Michael Seaton <mseaton@pih.org>, Andy Cotton <acotton@pih.org>"
 
 ARG DEBIAN_FRONTEND=noninteractive
 
 # We install firefox, as it is used by some modules (eg. coreapps) in Karma tests
-RUN apt-get update
-RUN apt-get install -y git lsb-release wget software-properties-common
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys A6DCF7707EBC211F
-RUN apt-add-repository "deb http://ppa.launchpad.net/ubuntu-mozilla-security/ppa/ubuntu focal main"
-RUN apt-get update
-RUN apt-get install -y firefox
-
 # library required by Puppeeter, which is used to run some Karma tests using ChromeHeadless
-RUN apt-get install -y fonts-liberation gconf-service libappindicator1 libasound2 libatk1.0-0 \
+# Selenium tests in some modules require there to be a valid file configured for OPENSSL_CONF
+RUN apt-get update \
+&& apt-get install -y firefox-esr docker\
+    fonts-liberation gconf-service libappindicator1 libasound2 libatk1.0-0 \
     libcairo2 libcups2 libfontconfig1 libgbm-dev libgdk-pixbuf2.0-0 libgtk-3-0 libicu-dev libjpeg-dev  \
     libnspr4 libnss3 libpango-1.0-0 libpangocairo-1.0-0 libpng-dev libx11-6 libx11-xcb1 libxcb1  \
-    libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6  xdg-utils
+    libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 xdg-utils \
+&& apt-get clean \
+&& touch /root/openssl.conf
 
-# Selenium tests in some modules require there to be a valid file configured for OPENSSL_CONF
-RUN touch /root/openssl.conf
+
+# Set Config home and work directories to allow running as non-root user, and for OPENSSL_CONF
 ENV OPENSSL_CONF=/root/openssl.conf
+ENV MAVEN_CONFIG=/var/maven/.m2
+ENV HOME /var/maven
+ENV MAVEN_HOME /var/maven
+ENV MAVEN_OPTS -Duser.home=/var/maven
+WORKDIR /data
 
-CMD ["mvn"]
+ENTRYPOINT ["mvn"]


### PR DESCRIPTION
Switch to  maven:3-jdk-8-slim image
Update MAINTAINER to LABEL to match current OCI spec
Consolidate RUN actions to reduce image layers
Added env vars for non-root
Changed CMD to ENTRYPOINT to simplify passing arguments.

I've tested mvn clean install with openmrs-core, petl (currently requires skipTests due to testcontainers), and openmrs-config-pihemr.

Image size reduced from 1.4GB to 1.18GB

Please let me know if you have any concerns or changes.